### PR TITLE
Fix the empty WordPress build artifact

### DIFF
--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create ZIP of built files
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
-        run: zip -r wordpress.zip build/
+        run: zip -r wordpress.zip .
 
       - name: Clean after building to run from ${{ inputs.directory }}
         run: npm run grunt clean${{ inputs.directory == 'src' && ' -- --dev' || '' }}

--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create ZIP of built files
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
-        run: zip -r wordpress.zip .
+        run: zip -r wordpress.zip build/.
 
       - name: Clean after building to run from ${{ inputs.directory }}
         run: npm run grunt clean${{ inputs.directory == 'src' && ' -- --dev' || '' }}

--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -68,15 +68,15 @@ jobs:
       - name: Ensure version-controlled files are not modified or deleted during building
         run: git diff --exit-code
 
+      - name: Create ZIP of built files
+        if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
+        run: zip -r wordpress.zip build/.
+
       - name: Clean after building to run from ${{ inputs.directory }}
         run: npm run grunt clean${{ inputs.directory == 'src' && ' -- --dev' || '' }}
 
       - name: Ensure version-controlled files are not modified or deleted during cleaning
         run: git diff --exit-code
-
-      - name: Create ZIP of built files
-        if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
-        run: zip -r wordpress.zip build
 
       - name: Upload ZIP as a GitHub Actions artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Create ZIP of built files
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
-        run: zip -r wordpress.zip build/.
+        run: zip -r wordpress.zip build
 
       - name: Upload ZIP as a GitHub Actions artifact
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2

--- a/.github/workflows/callable-test-core-build-process.yml
+++ b/.github/workflows/callable-test-core-build-process.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create ZIP of built files
         if: ${{ inputs.directory == 'build' && 'ubuntu-latest' == inputs.os }}
-        run: zip -r wordpress.zip build/.
+        run: zip -r wordpress.zip build/
 
       - name: Clean after building to run from ${{ inputs.directory }}
         run: npm run grunt clean${{ inputs.directory == 'src' && ' -- --dev' || '' }}


### PR DESCRIPTION
The zipped WordPress artifacts are 332 bytes large, this is an attempt to fix it:

<img width="561" alt="CleanShot 2023-12-07 at 22 05 10@2x" src="https://github.com/adamziel/wordpress-develop/assets/205419/0045e7c7-064d-46ad-b608-ddc30bf2b01d">
